### PR TITLE
Making pip cmd compatible with colab env

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # conda create -n consistent_depth python=3.6
 # conda activate consistent_depth
 # Note to set LD_LIBRARY_PATH if conda activate fails to do so.
-pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
+python3 -m pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
 pushd third_party/flownet2
 chmod +x install.sh
 ./install.sh


### PR DESCRIPTION
After modifying the python version on colab using and installing pip using:
`
!sudo update-alternatives --config python3
!sudo apt-get install python3-pip
`
we need to change pip commands to python3 -m pip